### PR TITLE
feat: adding payment refund

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ A Node.js SDK for First Iraqi Bank's online payment.
 - Payment Creation: Used to create a payment and getting QR codes and dynamic links to forward the user to the payment screen.
 - Checking payment status: Used to check the status of a payment.
 - Payment Cancellation: Used to cancel an active payment that has not been paid yet.
+- Payment Refund: Used to refund a paid payment.
 
 All methods use promise meaning you can either use the `async...await` or `then...catch` or `try...catch`
 
@@ -210,6 +211,14 @@ To refund a created payment, you can call the `refund()` method with your paymen
 
 ```js
 let refundPayment = await payment.refund(); // returns boolean
+```
+
+## Refunding a payment by ID
+You can also refund previous payments by their paymentId, you can call `refundById()` method as it follows:
+
+```js
+const refundPayment = await payment.refundById(paymentId:string);
+console.log(refundPayment); // returns boolean
 ```
 
 ## Develop and run Locally

--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ paymentStatusResponse.data = {
   // A unique identifier of the payment.
   paymentId: string,
 
-  // Expected values are: PAID | UNPAID | DECLINED.
+  // Expected values are: PAID | UNPAID | DECLINED | REFUND_REQUESTED | REFUNDED.
   status: string,
 
   // an ISO-8601-formatted date-time string, representing a moment in time when the payment expires.
@@ -199,6 +199,17 @@ To cancel a created payment, you can call the `cancel()` method with your paymen
 
 ```js
 let cancelPayment = await payment.cancel(); // returns boolean
+```
+
+## Refunding a payment
+To refund a created payment, you can call the `refund()` method with your payment instance and this will refund the payment from FIB and change the status of the payment instance to `REFUND_REQUESTED`, after a short of time status will change to `REFUNDED` and the amount will be refunded, The method returns a boolean value, it returns `true` if the refund was susccessful, if payment is not paid it will return `false`.
+
+### Notes
+- Only Payments with `PAID` status can be refunded.
+- Only payments that was paid in the last 24 hours can be refunded.
+
+```js
+let refundPayment = await payment.refund(); // returns boolean
 ```
 
 ## Develop and run Locally

--- a/src/payment/payment.ts
+++ b/src/payment/payment.ts
@@ -96,6 +96,25 @@ export default class Payment {
       .catch((err) => err);
   }
 
+  async refund(): Promise<boolean | BadRequest> {
+    await this.refreshRequestTokens();
+    return await this.http
+      .post(`/${this.paymentId}/refund`)
+      .then((response) => {
+        if (response.status === 202) {
+          this.reset();
+          return true;
+        } 
+        return false;
+      })
+      .catch((err) => {
+        if (err?.response?.data?.errors[0]?.code == 'TRANSACTION_STATUS_IS_NOT_PAID') {
+            return false;
+        }
+        return err;
+      });
+  }
+
   async refreshRequestTokens() {
     await axios
       .post(

--- a/src/payment/payment.ts
+++ b/src/payment/payment.ts
@@ -115,6 +115,25 @@ export default class Payment {
       });
   }
 
+  async refundById(paymentId: string): Promise<boolean | BadRequest> {
+    await this.refreshRequestTokens();
+    return await this.http
+      .post(`/${paymentId}/refund`)
+      .then((response) => {
+        if (response.status === 202) {
+          this.reset();
+          return true;
+        } 
+        return false;
+      })
+      .catch((err) => {
+        if (err?.response?.data?.errors[0]?.code == 'TRANSACTION_STATUS_IS_NOT_PAID') {
+            return false;
+        }
+        return err;
+      });
+  }
+
   async refreshRequestTokens() {
     await axios
       .post(

--- a/test/main.test.ts
+++ b/test/main.test.ts
@@ -40,3 +40,40 @@ describe('Testing payment process', () => {
     expect(isCanceled).toEqual(true);
   });
 });
+
+describe('Testing refund proccess', () => {
+  const fib = new Fib(client_id, client_secret, true);
+
+  it('creating an Fib class instance, authenticating, creating a payment, getting status and canceling the payment', async () => {
+    await fib.authenticate();
+    expect(fib.status).toEqual('READY');
+
+    const payment = fib.payment;
+    expect(payment.status).toEqual('NO_PAYMENT');
+
+    // creating payment
+    await payment.create({
+      monetaryValue: { amount: 5000, currency: 'IQD' },
+      description: 'test payment',
+    });
+
+    console.log('payment id: ', payment.paymentId);
+    console.log('payment status: ', payment.status);
+    expect(payment.status).toEqual('UNPAID');
+
+    // getting payment status
+    const paymentStatusResponse = await payment.getStatus();
+    console.log('payment status data: ', paymentStatusResponse.data);
+
+    // getting a payment status by ID
+    const paymentStatusByIdResponse = await payment.getStatusById(
+      payment.paymentId,
+    );
+    console.log('payment status by id data: ', paymentStatusByIdResponse.data);
+
+    // refund payment
+    // note it's not fully testable because there is no way you can pay using tests so then you can check if it's actually refunded.
+    const isRefunded = await payment.refund();
+    expect(isRefunded).toEqual(false);
+  });
+});

--- a/test/main.test.ts
+++ b/test/main.test.ts
@@ -75,5 +75,9 @@ describe('Testing refund proccess', () => {
     // note it's not fully testable because there is no way you can pay using tests so then you can check if it's actually refunded.
     const isRefunded = await payment.refund();
     expect(isRefunded).toEqual(false);
+
+    // refund payment by Id
+    const refundById = await payment.refundById(payment.paymentId);
+    expect(refundById).toEqual(false);
   });
 });


### PR DESCRIPTION
Hey Walid

Hope you have a nice day, I was reading the docs and I found out that `refund payment` is not implemented.

So I implemented `refund payment` -- > status 202 = refund requested

also, something weird happened when I called cancel payment and then refund payment the test was going crazy and getting timed out, so I made another test also refunding can't be fully tested so easily 🙂

Alongside implementing `refund payment` I updated the `README`